### PR TITLE
CSS: Slight readability improvements

### DIFF
--- a/public/css/reader-app.css
+++ b/public/css/reader-app.css
@@ -92,7 +92,7 @@
 
 .chapter > p:first-child::first-letter {
     float: left;
-    
+
     font-size: 94px;
     line-height: 81px;
     margin-right: 3px;
@@ -152,6 +152,14 @@
 
 ul.thread-list.reader .message {
     background-color: black;
+    padding: 8px 10px;
+    margin: 2px 0;
+}
+ul.thread-list.reader strong {
+    color: #fff;
+}
+ul.thread-list.reader li {
+    padding: 10px 0;
 }
 ul.thread-list.reader li .btn-bar {
     background-color: black;
@@ -179,7 +187,10 @@ ul.thread-list.reader li .btn-bar {
     overflow: hidden;
 }
 .reference-container.hidden {
-    height: 1.5em;
+    height: 2.25em;
+}
+.reference-container.hidden h2:first-child {
+    margin-bottom: 1em;
 }
 .arrow {
     width: 0;


### PR DESCRIPTION
In longer threads it's not easy to distinguish where messages start and end.
Added a slight gap between them and optimized paddings for readability.
Character names are displayed in white to have a very minimal distinction to the body text.
Also fixed the height of the reference container.

## Before

![bildschirmfoto 2018-10-10 um 18 27 38](https://user-images.githubusercontent.com/153481/46752323-2cf5ed80-ccbd-11e8-820f-99f96f6d6bf8.png)

![bildschirmfoto 2018-10-10 um 18 47 40](https://user-images.githubusercontent.com/153481/46752332-32533800-ccbd-11e8-938f-6bba490cc1ae.png)

## After

![bildschirmfoto 2018-10-10 um 18 33 00](https://user-images.githubusercontent.com/153481/46752361-45660800-ccbd-11e8-982e-b221ad36fe1f.png)

![bildschirmfoto 2018-10-10 um 18 48 01](https://user-images.githubusercontent.com/153481/46752342-3aab7300-ccbd-11e8-9db2-b49ed79b1ee0.png)
